### PR TITLE
Made HTTPS connections honor trusted certificates set in IntelliJ settings

### DIFF
--- a/src/com/ritesh/idea/plugin/reviewboard/ReviewBoardClient.java
+++ b/src/com/ritesh/idea/plugin/reviewboard/ReviewBoardClient.java
@@ -18,6 +18,7 @@ package com.ritesh.idea.plugin.reviewboard;
 
 import com.google.common.io.CharStreams;
 import com.intellij.openapi.vfs.CharsetToolkit;
+import com.intellij.util.net.ssl.CertificateManager;
 import com.ritesh.idea.plugin.exception.InvalidCredentialException;
 import com.ritesh.idea.plugin.exception.ReviewBoardServerException;
 import com.ritesh.idea.plugin.reviewboard.model.*;
@@ -171,7 +172,7 @@ public class ReviewBoardClient {
             HttpRequestBase request = HttpRequestBuilder.get(href)
                     .header(AUTHORIZATION, getAuthorizationHeader())
                     .request();
-            try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (CloseableHttpClient client = HttpClientBuilder.create().setSslcontext(CertificateManager.getInstance().getSslContext()).build()) {
                 CloseableHttpResponse response = client.execute(request);
 
                 if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {

--- a/src/com/ritesh/idea/plugin/util/HttpRequestBuilder.java
+++ b/src/com/ritesh/idea/plugin/util/HttpRequestBuilder.java
@@ -147,7 +147,7 @@ public class HttpRequestBuilder {
     public <T> T asJson(Class<T> clazz) throws IOException, URISyntaxException {
         try (CloseableHttpClient client = HttpClientBuilder.create()
                 .setDefaultRequestConfig(requestConfig)
-                .setSSLContext(CertificateManager.getInstance().getSslContext())
+                .setSslcontext(CertificateManager.getInstance().getSslContext())
                 .build()) {
             HttpRequestBase request = getHttpRequest();
             CloseableHttpResponse response = client.execute(request);
@@ -164,7 +164,7 @@ public class HttpRequestBuilder {
 
     public String asString() throws IOException, URISyntaxException {
         try (CloseableHttpClient client = HttpClientBuilder.create()
-                .setSSLContext(CertificateManager.getInstance().getSslContext())
+                .setSslcontext(CertificateManager.getInstance().getSslContext())
                 .setDefaultRequestConfig(requestConfig)
                 .build()) {
             HttpRequestBase request = getHttpRequest();

--- a/src/com/ritesh/idea/plugin/util/HttpRequestBuilder.java
+++ b/src/com/ritesh/idea/plugin/util/HttpRequestBuilder.java
@@ -18,6 +18,7 @@ package com.ritesh.idea.plugin.util;
 
 import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
+import com.intellij.util.net.ssl.CertificateManager;
 import com.ritesh.idea.plugin.exception.UnexpectedResponseException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
@@ -144,7 +145,10 @@ public class HttpRequestBuilder {
 
 
     public <T> T asJson(Class<T> clazz) throws IOException, URISyntaxException {
-        try (CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
+        try (CloseableHttpClient client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setSSLContext(CertificateManager.getInstance().getSslContext())
+                .build()) {
             HttpRequestBase request = getHttpRequest();
             CloseableHttpResponse response = client.execute(request);
             String content = CharStreams.toString(new InputStreamReader(response.getEntity().getContent()));
@@ -159,7 +163,10 @@ public class HttpRequestBuilder {
 
 
     public String asString() throws IOException, URISyntaxException {
-        try (CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
+        try (CloseableHttpClient client = HttpClientBuilder.create()
+                .setSSLContext(CertificateManager.getInstance().getSslContext())
+                .setDefaultRequestConfig(requestConfig)
+                .build()) {
             HttpRequestBase request = getHttpRequest();
             CloseableHttpResponse response = client.execute(request);
             return CharStreams.toString(new InputStreamReader(response.getEntity().getContent()));


### PR DESCRIPTION
Trusted certificates can be set in Preferences->Tools->Server Certificates

Without this change it is impossible to connect to HTTPS ReviewBoard servers without manually modifying certificate store in IntelliJ's bundled JRE.